### PR TITLE
Support multiple cards installed on a machine

### DIFF
--- a/nvml.py
+++ b/nvml.py
@@ -25,7 +25,7 @@ class NvmlCheck(AgentCheck):
             for device_id in xrange(deviceCount):
                 handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
                 name = pynvml.nvmlDeviceGetName(handle)
-                tags = dict(name=name)
+                tags = dict(name="{}-{}".format(name,device_id))
                 d_tags = self._dict2list(tags)
                 temp = pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
                 info = pynvml.nvmlDeviceGetMemoryInfo(handle)


### PR DESCRIPTION
When more than one same cards are installed on a machine, we won't be able to distinguish without adding the device_id to the "name" field.

the new name will become <Card name>-<device id>
e.g., 
geforce_gtx_titan_x-0
