### PR TITLE
Add gauges: num of GPUs, clocks throttle reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Currently we will acquire the following items for each GPU.
 - nvml.mem.used: Used Memory
 - nvml.mem.free: Free Memory
 - nvml.temp: Temperature
+- nvml.gpus.number: Number of active GPUs
+- nvml.throttle.appsettings: Clocks are being throttled by the applications settings
+- nvml.throttle.display: Clocks are being throttled by the Display clocks settings
+- nvml.throttle.hardware: Clocks are being throttled by a factor of 2 or more due to high temperature, high power draw, and/or PState or clock change
+- nvml.throttle.power.hardware: Clocks are being throttled due to the External Power Brake Assertion being triggered (e.g., by the system power supply)
+- nvml.throttle.idle: Clocks are being throttled to Idle state because nothing is running on the GPU
+- nvml.throttle.power.software: Clocks are being throttled by the software power scaling algorithm
+- nvml.throttle.syncboost: Clocks are being throttled because this GPU is in a sync boost group and will sync to the lowest possible clocks across the group
+- nvml.throttle.temp.hardware: Clocks are being throttled by a factor of 2 or more due to high temperature
+- nvml.throttle.temp.software: Clocks are being throttled due to high GPU core and/or memory temperature
+- nvml.throttle.unknown: Clocks are being throttled due to an unknown reason
 
 (*) HW accelerated encode and decode are supported on NVIDIA GeForce, Quadro, Tesla, and GRID products with Fermi, Kepler, Maxwell and Pascal generation GPUs.
 

--- a/nvml.py
+++ b/nvml.py
@@ -17,6 +17,26 @@ import pynvml
 __version__ = '0.1.5'
 __author__ = 'Takashi NAGAI, Alejandro Ferrari'
 
+# These values are not exposed through Pynvml, but are reported in the throttle
+# reasons. The reason values are defined in
+# https://github.com/NVIDIA/gpu-monitoring-tools/blob/master/bindings/go/nvml/nvml.h
+# Indicates that the clocks are throttled because the GPU is part of a sync
+# boost group, which syncs the clocks to the minimum clocks across the group.
+# Corresponds to nvmlClocksThrottleReasonSyncBoost.
+GPU_THROTTLE_SYNCBOOST = 0x10
+# Indicates that the GPU core or memory temperature is above max. Corresponds to
+# nvmlClocksThrottleReasonSwThermalSlowdown.
+GPU_THROTTLE_THERMAL_SLOWDOWN_SOFTWARE = 0x20
+# Indicates that the clocks are throttled by 50% or more due to very high
+# temperature. Corresponds to nvmlClocksThrottleReasonHwThermalSlowdown.
+GPU_THROTTLE_THERMAL_SLOWDOWN_HARDWARE = 0x40
+# Indicates that the clocks are throttled by 50% or more by the power supply.
+# Corresponds to nvmlClocksThrottleReasonHwPowerBrakeSlowdown.
+GPU_THROTTLE_POWER_BRAKE_SLOWDOWN_HARDWARE = 0x80
+# Indicates that the clocks are throttled by the current display settings.
+# Corresponds to nvmlClocksThrottleReasonDisplayClockSetting.
+GPU_THROTTLE_DISPLAY_CLOCKS_SETTINGS = 0x100
+
 
 class NvmlCheck(AgentCheck):
 
@@ -31,6 +51,8 @@ class NvmlCheck(AgentCheck):
             deviceCount = pynvml.nvmlDeviceGetCount()
         except:
             deviceCount = 0
+        # Number of active GPUs
+        self.gauge('nvml.gpus.number', deviceCount)
         for device_id in xrange(deviceCount):
             handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
             name = pynvml.nvmlDeviceGetName(handle)
@@ -102,6 +124,53 @@ class NvmlCheck(AgentCheck):
             except pynvml.NVMLError as err:
                 msg_list.append(
                     u'nvmlDeviceGetComputeRunningProcesses:{}'.format(err))
+            # Clocks throttling info
+            # Divide by the mask so that the value is either 0 or 1 per GPU
+            try:
+                throttle_reasons = (
+                    pynvml.nvmlDeviceGetCurrentClocksThrottleReasons(handle))
+                self.gauge('nvml.throttle.appsettings', (throttle_reasons &
+                    pynvml.nvmlClocksThrottleReasonApplicationsClocksSetting) /
+                    pynvml.nvmlClocksThrottleReasonApplicationsClocksSetting,
+                    tags=d_tags)
+                self.gauge('nvml.throttle.display', (throttle_reasons &
+                    GPU_THROTTLE_DISPLAY_CLOCKS_SETTINGS) /
+                    GPU_THROTTLE_DISPLAY_CLOCKS_SETTINGS,
+                    tags=d_tags)
+                self.gauge('nvml.throttle.hardware', (throttle_reasons &
+                    pynvml.nvmlClocksThrottleReasonHwSlowdown) /
+                    pynvml.nvmlClocksThrottleReasonHwSlowdown,
+                    tags=d_tags)
+                self.gauge('nvml.throttle.idle', (throttle_reasons &
+                    pynvml.nvmlClocksThrottleReasonGpuIdle) /
+                    pynvml.nvmlClocksThrottleReasonGpuIdle,
+                    tags=d_tags)
+                self.gauge('nvml.throttle.power.hardware', (throttle_reasons &
+                    GPU_THROTTLE_POWER_BRAKE_SLOWDOWN_HARDWARE) /
+                    GPU_THROTTLE_POWER_BRAKE_SLOWDOWN_HARDWARE,
+                    tags=d_tags)
+                self.gauge('nvml.throttle.power.software', (throttle_reasons &
+                    pynvml.nvmlClocksThrottleReasonSwPowerCap) /
+                    pynvml.nvmlClocksThrottleReasonSwPowerCap,
+                    tags=d_tags)
+                self.gauge('nvml.throttle.syncboost', (throttle_reasons &
+                    GPU_THROTTLE_SYNCBOOST) / GPU_THROTTLE_SYNCBOOST,
+                    tags=d_tags)
+                self.gauge('nvml.throttle.temp.hardware', (throttle_reasons &
+                    GPU_THROTTLE_THERMAL_SLOWDOWN_HARDWARE) /
+                    GPU_THROTTLE_THERMAL_SLOWDOWN_HARDWARE,
+                    tags=d_tags)
+                self.gauge('nvml.throttle.temp.software', (throttle_reasons &
+                    GPU_THROTTLE_THERMAL_SLOWDOWN_SOFTWARE) /
+                    GPU_THROTTLE_THERMAL_SLOWDOWN_SOFTWARE,
+                    tags=d_tags)
+                self.gauge('nvml.throttle.unknown', (throttle_reasons &
+                    pynvml.nvmlClocksThrottleReasonUnknown) /
+                    pynvml.nvmlClocksThrottleReasonUnknown,
+                    tags=d_tags)
+            except pynvml.NVMLError as err:
+                msg_list.append(
+                    u'nvmlDeviceGetCurrentClocksThrottleReasons:{}'.format(err))
         if msg_list:
             status = AgentCheck.CRITICAL
             msg = u','.join(msg_list)


### PR DESCRIPTION
Adds the gauges:
- nvml.gpus.number
- nvml.throttle.appsettings
- nvml.throttle.display
- nvml.throttle.hardware
- nvml.throttle.idle
- nvml.throttle.power.hardware
- nvml.throttle.power.software
- nvml.throttle.syncboost
- nvml.throttle.temp.hardware
- nvml.throttle.temp.software
- nvml.throttle.unknown

This also updates `README.md` with a short explanation of these gauges.

Why:
The number of GPUs reported by NVML is highly valuable in monitoring
the health of GPU-enabled hosts (e.g., this can indicate when a GPU
encounters a severe error and "falls off" the PCIe bus). Alerts can be
created from this gauge to notify the appropriate parties and resolve/
investigate the situation.

Information on if and why clocks are being throttled on a GPU are also
highly valuable for monitoring the health of GPU-enabled hosts (e.g.,
this can indicate when physical maintainence or upgrades may be
required to clear dust, replace/upgrade case fans, replace/upgrade the
external cooling system, etc.). Also, providing explicit information on
the exact throttle reason is useful to determine the severity of the
throttling issue (e.g., seeing `nvml.throttle.temp.software` indicates
less severe overheating than `nvml.throttle.temp.hardware`).
Pynvml doesn't expose all of the throttle reasons returned by the call
to `nvmlDeviceGetCurrentClocksThrottleReasons` as enums, so several
reasons are explicitly defined to be equal to their values in the file
`https://github.com/NVIDIA/gpu-monitoring-tools/blob/master/bindings/go/nvml/nvml.h`.
These are:
- GPU_THROTTLE_SYNCBOOST
- GPU_THROTTLE_THERMAL_SLOWDOWN_SOFTWARE
- GPU_THROTTLE_THERMAL_SLOWDOWN_HARDWARE
- GPU_THROTTLE_POWER_BRAKE_SLOWDOWN_HARDWARE
- GPU_THROTTLE_DISPLAY_CLOCKS_SETTINGS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ngi644/datadog_nvml/9)
<!-- Reviewable:end -->
