### PR TITLE
chore: Bump nvidia-ml-py to v12.555.43

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,23 @@ Currently we will acquire the following items for each GPU.
 
 # REQUIRES
 
-nvidia-ml-py (v7.352.0)
+nvidia-ml-py (v12.555.43)
 
 - https://pypi.python.org/pypi/nvidia-ml-py
 
 ```
 # Python 2
-$ sudo /opt/datadog-agent/embedded/bin/pip install nvidia-ml-py==7.352.0
+$ sudo /opt/datadog-agent/embedded/bin/pip install nvidia-ml-py==12.555.43
 
 # Python 3
-$ sudo /opt/datadog-agent/embedded/bin/pip install nvidia-ml-py3==7.352.0
+$ sudo /opt/datadog-agent/embedded/bin/pip install nvidia-ml-py3==12.555.43
 ```
 
 Check that was correctly installed:
 ```
 # /opt/datadog-agent/embedded/bin/pip show nvidia-ml-py
 Name: nvidia-ml-py
-Version: 7.352.0
+Version: 12.555.43
 Summary: Python Bindings for the NVIDIA Management Library
 Home-page: http://www.nvidia.com/
 Author: NVIDIA Corporation
@@ -145,7 +145,7 @@ $ docker run -d --gpus=all \
 # Tested
   Tested on AWS EC2 G2 Familly (g2.2xlarge) that include 1x NVIDIA GRID K520 card.
   Tested on Bare-metal Supermicro server with NVIDIA TESLA P4 and P40 cards.
-  
+
 # References
 
 - https://pypi.python.org/pypi/nvidia-ml-py/

--- a/nvml.py
+++ b/nvml.py
@@ -124,53 +124,6 @@ class NvmlCheck(AgentCheck):
             except pynvml.NVMLError as err:
                 msg_list.append(
                     'nvmlDeviceGetComputeRunningProcesses:{}'.format(err))
-            # Clocks throttling info
-            # Divide by the mask so that the value is either 0 or 1 per GPU
-            try:
-                throttle_reasons = (
-                    pynvml.nvmlDeviceGetCurrentClocksThrottleReasons(handle))
-                self.gauge('nvml.throttle.appsettings', (throttle_reasons &
-                    pynvml.nvmlClocksThrottleReasonApplicationsClocksSetting) /
-                    pynvml.nvmlClocksThrottleReasonApplicationsClocksSetting,
-                    tags=d_tags)
-                self.gauge('nvml.throttle.display', (throttle_reasons &
-                    GPU_THROTTLE_DISPLAY_CLOCKS_SETTINGS) /
-                    GPU_THROTTLE_DISPLAY_CLOCKS_SETTINGS,
-                    tags=d_tags)
-                self.gauge('nvml.throttle.hardware', (throttle_reasons &
-                    pynvml.nvmlClocksThrottleReasonHwSlowdown) /
-                    pynvml.nvmlClocksThrottleReasonHwSlowdown,
-                    tags=d_tags)
-                self.gauge('nvml.throttle.idle', (throttle_reasons &
-                    pynvml.nvmlClocksThrottleReasonGpuIdle) /
-                    pynvml.nvmlClocksThrottleReasonGpuIdle,
-                    tags=d_tags)
-                self.gauge('nvml.throttle.power.hardware', (throttle_reasons &
-                    GPU_THROTTLE_POWER_BRAKE_SLOWDOWN_HARDWARE) /
-                    GPU_THROTTLE_POWER_BRAKE_SLOWDOWN_HARDWARE,
-                    tags=d_tags)
-                self.gauge('nvml.throttle.power.software', (throttle_reasons &
-                    pynvml.nvmlClocksThrottleReasonSwPowerCap) /
-                    pynvml.nvmlClocksThrottleReasonSwPowerCap,
-                    tags=d_tags)
-                self.gauge('nvml.throttle.syncboost', (throttle_reasons &
-                    GPU_THROTTLE_SYNCBOOST) / GPU_THROTTLE_SYNCBOOST,
-                    tags=d_tags)
-                self.gauge('nvml.throttle.temp.hardware', (throttle_reasons &
-                    GPU_THROTTLE_THERMAL_SLOWDOWN_HARDWARE) /
-                    GPU_THROTTLE_THERMAL_SLOWDOWN_HARDWARE,
-                    tags=d_tags)
-                self.gauge('nvml.throttle.temp.software', (throttle_reasons &
-                    GPU_THROTTLE_THERMAL_SLOWDOWN_SOFTWARE) /
-                    GPU_THROTTLE_THERMAL_SLOWDOWN_SOFTWARE,
-                    tags=d_tags)
-                self.gauge('nvml.throttle.unknown', (throttle_reasons &
-                    pynvml.nvmlClocksThrottleReasonUnknown) /
-                    pynvml.nvmlClocksThrottleReasonUnknown,
-                    tags=d_tags)
-            except pynvml.NVMLError as err:
-                msg_list.append(
-                    'nvmlDeviceGetCurrentClocksThrottleReasons:{}'.format(err))
         if msg_list:
             status = AgentCheck.CRITICAL
             msg = ','.join(msg_list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-nvidia-ml-py==7.352.0
+nvidia-ml-py==12.555.43


### PR DESCRIPTION
The datadog agent upgraded to Python 3.11 in v7.51.0 and at the same time uprgaded `google/protobuf` to a version that is unsupported by the very old version of `nvidia-ml-py`.

This upgrades `nvidia-ml-py` to the latest version. Some APIs related to throttling was no longer in the library, so I removed the reference to those.

This is confirmed working with NVML v555.42.02.